### PR TITLE
Disable cache updating

### DIFF
--- a/tasks/common_packages.yml
+++ b/tasks/common_packages.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install common packages @Debian
   apt:
-    update_cache: yes
     name:
       - vim-nox
       - git


### PR DESCRIPTION
This is supposed to be done by the update script and will just mark this
host as modified even when no packages were updated.