### PR TITLE
Revert "Add systemd to main"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,3 @@
 ---
 - include: common_packages.yml
 - include: users.yml
-- include: systemd.yml


### PR DESCRIPTION
Reverts stuvusIT/common#4

systemd gibt es weder bei freebsd noch bei gentoo. 