### PR TITLE
Make SSH configuration more secure

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,3 @@
 ---
 - include: systemd.yml
+- include: ssh.yml

--- a/handlers/ssh.yml
+++ b/handlers/ssh.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart sshd
+  service:
+    name: sshd.service
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 - include: common_packages.yml
 - include: users.yml
+- include: ssh.yml
+  when: ansible_os_family != "FreeBSD"
 - include: systemd.yml
   when: ansible_service_mgr == "systemd"

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -1,0 +1,179 @@
+---
+- name: Ensure the Host part of the client config is commented in
+  lineinfile:
+    name: /etc/ssh/ssh_config
+    regexp: "^\\s#?\\s*Host \\*"
+    line: "Host *"
+
+- name: Force SSH Version 2
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*Protocol"
+    line: "Protocol 2"
+  notify: Restart sshd
+
+- name: Disable weak SSH server key exchange algorithms
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*KexAlgorithms"
+    line: "KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256"
+  notify: Restart sshd
+
+- name: Disable wek SSH client key exchange algorithms
+  lineinfile:
+    name: /etc/ssh/ssh_config
+    regexp: "^\\s*#?\\s*KexAlgorithms"
+    line: "    KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256"
+    insertafter: "^\\s*Host \\*"
+
+- name: Disable weak SSH server key algorithms for authentication
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*HostKey.*/ssh_host_{{ item }}_key$"
+    state: absent
+  with_items:
+    - dsa
+    - ecdsa
+  notify: Restart sshd
+
+- name: Disable weak SSH client key algorithms for authentication
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#\\s*HostKey.*/ssh_host_{{ item }}_key$"
+    state: absent
+    insertafter: "^\\s*Host \\*"
+  with_items:
+    - dsa
+    - ecdsa
+  notify: Restart sshd
+
+- name: Delete weak SSH server keys
+  file:
+    name: /etc/ssh/{{ item }}
+    state: absent
+  with_items:
+    - ssh_host_ecdsa_key
+    - ssh_host_ecdsa_key.pub
+    - ssh_host_dsa_key
+    - ssh_host_dsa_key.pub
+
+- name: Create strong SSH server keys
+  command:
+    cmd: ssh-keygen -b 8192 -t {{ item }} -f /etc/ssh/ssh_host_{{ item }}_key -N ""
+    creates: /etc/ssh/ssh_host_{{ item }}_key
+  with_items:
+    - rsa
+    - ed25519
+  notify: Restart sshd
+
+- name: Disable SSH password authentication (1/2)
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*PasswordAuthentication"
+    line: "PasswordAuthentication no"
+  notify: Restart sshd
+
+- name: Disable SSH password authentication (2/2)
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*ChallengeResponseAuthentication"
+    line: "ChallengeResponseAuthentication no"
+  notify: Restart sshd
+
+- name: Enable SSH public key authentication in server
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*PubkeyAuthentication"
+    line: "PubkeyAuthentication yes"
+  notify: Restart sshd
+
+- name: Enable SSH public key authentication in client
+  lineinfile:
+    name: /etc/ssh/ssh_config
+    regexp: "^\\s*#?\\s*PubkeyAuthentication"
+    line: "    PubkeyAuthentication yes"
+    insertafter: "^\\s*Host \\*"
+
+- name: Disable weak server keys in SSH client
+  lineinfile:
+    name: /etc/ssh/ssh_config
+    regexp: "^\\s*#?\\s*HostKeyAlgorithms"
+    line: "    HostKeyAlgorithms ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa"
+    insertafter: "^\\s*Host \\*"
+
+- name: Require group memebership to connect via SSH
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*AllowGroups"
+    line: "AllowGroups ssh-users"
+  notify: Restart sshd
+
+- name: Disable root login via SSH
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*PermitRootLogin"
+    line: "PermitRootLogin no"
+  notify: Restart sshd
+
+- name: Disable weak SSH server ciphers
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*Ciphers"
+    line: "Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+  notify: Restart sshd
+
+- name: Disable weak SSH client ciphers
+  lineinfile:
+    name: /etc/ssh/ssh_config
+    regexp: "^\\s*#?\\s*Ciphers"
+    line: "    Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+    insertafter: "^\\s*Host \\*"
+
+- name: Disable weak SSH server MACs
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*MACs"
+    line: "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com"
+  notify: Restart sshd
+
+- name: Enable sshd keepalives
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^\\s*#?\\s*ClientAliveInterval"
+    line: "ClientAliveInterval 120"
+  notify: Restart sshd
+
+- name: Disable weak SSH client MACs
+  lineinfile:
+    name: /etc/ssh/ssh_config
+    regexp: "^\\s*#?\\s*MACs"
+    line: "    MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com"
+    insertafter: "^\\s*Host \\*"
+
+- name: Check if sshd moduli were generated
+  stat:
+    path: /etc/ssh/.moduli-generated
+  register: sshd_moduli
+
+- name: Generate all sshd moduli
+  command: ssh-keygen -G /etc/ssh/moduli.all -b 8192
+  when: not sshd_moduli.stat.exists
+
+- name: Filter out safe sshd moduli
+  command: ssh-keygen -T /etc/ssh/moduli.safe -f /etc/ssh/moduli.all
+  when: not sshd_moduli.stat.exists
+
+- name: Move sshd moduli
+  command: mv /etc/ssh/moduli.safe /etc/ssh/moduli
+  when: not sshd_moduli.stat.exists
+  notify: Restart sshd
+
+- name: Create sshd moduli flag
+  file:
+    path: /etc/ssh/.moduli-generated
+    state: touch
+
+- name: Delete temporary moduli file
+  file:
+    path: /etc/ssh/moduli.all
+    state: absent

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -5,11 +5,16 @@
     state: present
     system: true
 
+- name: Make sure SSH group is present
+  group:
+    name: ssh-users
+    system: true
+
 - name: Create admin users
   user:
     comment: "{{ item.value.name }}"
     createhome: true
-    groups: dialout,users,wheel
+    groups: dialout,users,wheel,ssh-users
     state: present
     system: no
     name: "{{ item.key }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -45,14 +45,6 @@
     validate_certs: true
   with_items: "{{ admins }}"
 
-- name: Update ssh keys for root
-  authorized_key:
-    exclusive: true
-    key: "{% for user in admins %}{% for key in admins[user]['keys'] %}{{ key }}\n{% endfor %}{% endfor %}"
-    state: present
-    user: "root"
-    validate_certs: true
-
 - name: Grant all admin users root privilages
   lineinfile:
     create: true


### PR DESCRIPTION
- Force SSH Protocol version 2
- Disable weak KEX algorithms (Server and Client)
- Disable weak Key algorithms (Server and Client)
- Disable weak Ciphers (Server and Client)
- **Force usage of strong (RSA or ED25519) server keys**
- **Disable password authentication**
- **Require group membership to log in via ssh**
- **Forbid root login**
- Send keepalive packets from server
- Regenerate DH moduli

DH moduli regeneration takes a long time, but is only done once.