### PR TITLE
Put all users in the adm group

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -14,7 +14,7 @@
   user:
     comment: "{{ item.value.name }}"
     createhome: true
-    groups: dialout,users,wheel,ssh-users
+    groups: adm,dialout,users,wheel,ssh-users
     state: present
     system: no
     name: "{{ item.key }}"


### PR DESCRIPTION
The adm group is the group which can read the entire systemd journal.
This is so we don't need to be root every time we want to see the whole journal.