### PR TITLE
Also install dbus package

### DIFF
--- a/tasks/common_packages.yml
+++ b/tasks/common_packages.yml
@@ -21,3 +21,4 @@
       - iputils-ping
       - less
       - psmisc
+      - dbus


### PR DESCRIPTION
This package is not installed on pis generated by our role, but is needed to set the hostname via ansible.