### PR TITLE
Add net-tools

### DIFF
--- a/tasks/common_packages.yml
+++ b/tasks/common_packages.yml
@@ -33,3 +33,4 @@
       - dbus
       - locales
       - nfs-client
+      - net-tools


### PR DESCRIPTION
net-tools contains some commonly used network utils such as netstat.