### PR TITLE
htoprc: Show numerical memory infos instead of battery

### DIFF
--- a/templates/htoprc.j2
+++ b/templates/htoprc.j2
@@ -21,5 +21,5 @@ color_scheme=5
 delay=15
 left_meters=AllCPUs2 CPU Memory Swap
 left_meter_modes=1 1 1 1
-right_meters=Hostname Tasks LoadAverage Uptime Battery
+right_meters=Hostname Tasks LoadAverage Memory Uptime
 right_meter_modes=2 2 2 2 2


### PR DESCRIPTION
It looks like this now:
![image](https://user-images.githubusercontent.com/4971975/38456441-1c15b89e-3a85-11e8-901b-bdbaf66e310f.png)
