### PR TITLE
htoprc: Customize columns

### DIFF
--- a/templates/htoprc.j2
+++ b/templates/htoprc.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
-fields=0 48 17 18 38 39 40 2 46 47 111 20 49 1
-sort_key=46
+fields=0 48 18 50 39 40 2 46 47 111 20 49 1
+sort_key=47
 sort_direction=1
 hide_threads=0
 hide_kernel_threads=1


### PR DESCRIPTION
Hide prio and virtual memory (not really needed), but add amount of threads (as we hide the threads by default).
Also sort by MEM% instead of CPU% when not in tree mode