### PR TITLE
Refactor sensible config deployment; Add zshenv

### DIFF
--- a/tasks/sensible-stuff.yml
+++ b/tasks/sensible-stuff.yml
@@ -1,16 +1,15 @@
 ---
-- name: Install sensible zshrc
+- name: "Install sensible {{ item.key }} configuration"
   template:
-    src: zshrc.j2
-    dest: /etc/zsh/zshrc
+    src: "{{ item.key }}.j2"
+    dest: "{{ item.value }}"
     owner: root
     group: root
     mode: 0644
+  loop: "{{ template_paths | dict2items }}"
+  vars:
+    template_paths:
+      zshrc: /etc/zsh/zshrc
+      zshenv: /etc/zsh/zshenv
+      htoprc: /etc/htoprc
 
-- name: Install sensible htoprc
-  template:
-    src: htoprc.j2
-    dest: /etc/htoprc
-    owner: root
-    group: root
-    mode: 0644

--- a/templates/zshenv.j2
+++ b/templates/zshenv.j2
@@ -1,0 +1,23 @@
+# {{ ansible_managed }}
+# /etc/zsh/zshenv: system-wide .zshenv file for zsh(1).
+#
+# This file is sourced on all invocations of the shell.
+# If the -f flag is present or if the NO_RCS option is
+# set within this file, all other initialization files
+# are skipped.
+#
+# This file should contain commands to set the command
+# search path, plus other important environment variables.
+# This file should not contain commands that produce
+# output or assume the shell is attached to a tty.
+# Global Order: zshenv, zprofile, zshrc, zlogin
+
+if [[ -z "$PATH" || "$PATH" == "/bin:/usr/bin" ]]
+then
+        export PATH="/usr/local/bin:/usr/bin:/bin"
+fi
+
+# Override zsh-newuser-install function
+# -> users use /etc/zshrc without having to choose anything in the menu
+zsh-newuser-install() { :; }
+


### PR DESCRIPTION
zshenv disables the newuser install prompt, resulting in the /etc/zshrc
config being used without any user input