### PR TITLE
tasks/sensible-stuff.yml: Don't use {{ item.key }} in an invalid way

### DIFF
--- a/tasks/sensible-stuff.yml
+++ b/tasks/sensible-stuff.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Install sensible {{ item.key }} configuration"
+- name: Instantiate sensible configuration templates
   template:
     src: "{{ item.key }}.j2"
     dest: "{{ item.value }}"


### PR DESCRIPTION
At the changed place, the Jinja2 wasn't instantiated.