### PR TITLE
chore(locale_gen): Ansible 2.10 compatibility for locale_gen

### DIFF
--- a/tasks/locale.yml
+++ b/tasks/locale.yml
@@ -6,7 +6,7 @@
     line: "XKBLAYOUT={{ common_keyboard_layout }}"
 
 - name: Install locales
-  locale_gen:
+  community.general.locale_gen:
     name: "{{ item }}"
   with_items: "{{ common_locales }}"
 


### PR DESCRIPTION
Since Ansible 2.10, `locale_gen` is no longer a part of Ansible. It can be obtained from the Ansible Galaxy collection `community.general`. Note that this change probably breaks compatibility with Ansible <= 2.8.