### PR TITLE
fix(ansible-2.10): Take authorized_key module from collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 ## Requirements
 
-A Debian-based distribution.
+- Remotely: A Debian-based distribution.
+- Locally: Ansible 2.9 or newer with the `ansible.posix` collection installed.
 
 ## Role Variables
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -33,7 +33,7 @@
   loop: "{{ common_jumphost_users | dict2items }}"
 
 - name: Update SSH keys for admins and users
-  authorized_key:
+  ansible.posix.authorized_key:
     exclusive: true
     key: "{% for key in item.value['keys'] %}{{ key }}\n{% endfor %}"
     user: "{{ item.key }}"
@@ -41,7 +41,7 @@
   loop: "{{ common_admin_users | dict2items + common_users | dict2items }}"
 
 - name: Update SSH keys for JumpHost users
-  authorized_key:
+  ansible.posix.authorized_key:
     exclusive: true
     key: "{% for key in item.value['keys'] %}{{ key }}\n{% endfor %}"
     user: "{{ item.key }}"


### PR DESCRIPTION
Since Ansible 2.10 the `authorized_key` module is no longer available. Since Ansible 2.9 there's the replacement `ansible.posix.authorized_key` in the `ansible.posix` collection.